### PR TITLE
fix(a11y): add disabled attribute to login button

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -68,6 +68,7 @@ export default function LoginPage() {
 
                     <button
                         className="w-full py-3.5 rounded-xl bg-primary font-semibold text-white shadow-[0_0_20px_rgba(139,92,246,0.3)] hover:shadow-[0_0_30px_rgba(139,92,246,0.5)] hover:bg-primary/90 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                        disabled={isPending}
                         aria-disabled={isPending}
                     >
                         {isPending ? 'Signing in...' : 'Sign in'}


### PR DESCRIPTION
## Summary
- Adds `disabled={isPending}` to the login submit button alongside the existing `aria-disabled`
- Prevents double-submission during form pending state
- The existing `disabled:opacity-50 disabled:cursor-not-allowed` CSS classes now actually take effect

## Test plan
- [ ] Navigate to `/login`, submit the form, and verify the button is visually dimmed and unclickable while pending
- [ ] Verify screen readers announce the button as disabled during submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)