### PR TITLE
fix(a11y): add prefers-reduced-motion support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -149,3 +149,15 @@ input[type="range"]::-moz-range-thumb:hover {
   transform: scale(1.2);
   box-shadow: 0 0 15px rgba(139, 92, 246, 0.8);
 }
+
+/* Respect user's motion preferences (WCAG 2.1 SC 2.3.3) */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `@media (prefers-reduced-motion: reduce)` block to `globals.css`
- Disables all animations (fade-in, slide-up, pulse) and transitions when the user's OS has reduced motion enabled
- Uses `0.01ms` duration (not `0s`) to ensure animation end-states still apply
- WCAG 2.1 Success Criterion 2.3.3

## Test plan
- [ ] Enable "Reduce motion" in macOS (System Settings > Accessibility > Display) or equivalent OS setting
- [ ] Verify the landing page background gradients stop pulsing
- [ ] Verify hover effects on glass cards are instant (no slide/fade)
- [ ] Disable the setting and verify animations return to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)