### PR TITLE
perf: migrate all img tags to next/image

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -18,6 +18,7 @@ type Props = {
     searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
+import Image from "next/image"
 import { DashboardShell } from "@/components/DashboardShell"
 
 // ... imports remain same ...
@@ -161,7 +162,7 @@ export default async function DashboardPage({ searchParams }: Props) {
         <>
             <div className="p-6 border-b border-white/10 flex items-center justify-between">
                 <Link href="/dashboard" className="text-xl font-bold tracking-tighter text-white flex items-center gap-2">
-                    {brandingOrg?.logoUrl && <img src={brandingOrg.logoUrl} alt="Logo" className="w-6 h-6 object-contain" />}
+                    {brandingOrg?.logoUrl && <Image src={brandingOrg.logoUrl} alt="Logo" width={24} height={24} className="object-contain" />}
                     <span>{brandingOrg?.siteName || "myJournal"}</span>
                 </Link>
                 <Link href="/settings" className="text-gray-400 hover:text-white transition-colors">
@@ -209,7 +210,7 @@ export default async function DashboardPage({ searchParams }: Props) {
                     <div className="flex items-center gap-2">
                         <div className="w-8 h-8 rounded-full bg-gradient-to-br from-primary to-purple-600 flex items-center justify-center text-xs font-bold text-white overflow-hidden border border-white/10">
                             {avatarUrl ? (
-                                <img src={avatarUrl} alt="Avatar" className="w-full h-full object-cover" />
+                                <Image src={avatarUrl} alt="Avatar" width={32} height={32} className="w-full h-full object-cover" />
                             ) : (
                                 (currentUser?.name?.[0] || currentUser?.email?.[0] || '?').toUpperCase()
                             )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import { getActiveOrganization } from "@/app/lib/data"
 
 export default async function Home() {
@@ -18,7 +19,7 @@ export default async function Home() {
         <header className="absolute top-0 w-full p-6 flex justify-between items-center max-w-7xl mx-auto">
           <div className="flex items-center gap-3">
             {/* Logo would go here if we had one specific logic for it, or just text */}
-            {org?.logoUrl && <img src={org.logoUrl} alt="Logo" className="w-8 h-8 object-contain" />}
+            {org?.logoUrl && <Image src={org.logoUrl} alt="Logo" width={32} height={32} className="object-contain" />}
             <div className="text-xl font-bold tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-white to-white/70">
               {org?.siteName || "myJournal"}
             </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma"
 import { auth } from "@/auth"
 import { redirect } from "next/navigation"
 import Link from "next/link"
+import Image from "next/image"
 import { ProfileForm } from "./ProfileForm"
 import { ChangePasswordDialog } from "@/components/ChangePasswordDialog"
 
@@ -49,7 +50,7 @@ export default async function SettingsPage() {
             {/* Simple Sidebar/Nav Back */}
             <div className="w-64 border-r border-white/10 bg-black/20 flex flex-col p-4">
                 <Link href="/dashboard" className="text-xl font-bold tracking-tighter text-white mb-8 flex items-center gap-2">
-                    {org?.logoUrl && <img src={org.logoUrl} alt="Logo" className="w-6 h-6 object-contain" />}
+                    {org?.logoUrl && <Image src={org.logoUrl} alt="Logo" width={24} height={24} className="object-contain" />}
                     <span>{org?.siteName || "myJournal"}</span>
                 </Link>
                 <Link href="/dashboard" className="flex items-center gap-3 px-3 py-2 rounded-lg text-gray-400 hover:text-white hover:bg-white/5 transition-colors">

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -6,6 +6,7 @@ import { getUserStats } from "@/app/lib/analytics"
 import { getActiveOrganization } from "@/app/lib/data"
 import { AdminUserSelector } from "@/components/AdminUserSelector"
 import Link from "next/link"
+import Image from "next/image"
 import { ContributionHeatmap } from "@/components/ContributionHeatmap"
 import { TimeOfDayChart } from "@/components/stats/TimeOfDayChart"
 import { WordCloud } from "@/components/stats/WordCloud"
@@ -63,7 +64,7 @@ export default async function StatsPage({ searchParams }: Props) {
             <div className="w-64 border-r border-white/10 hidden md:flex flex-col bg-black/50">
                 <div className="p-6 border-b border-white/10">
                     <Link href="/dashboard" className="text-xl font-bold tracking-tighter text-white flex items-center gap-2">
-                        {org?.logoUrl && <img src={org.logoUrl} alt="Logo" className="w-6 h-6 object-contain" />}
+                        {org?.logoUrl && <Image src={org.logoUrl} alt="Logo" width={24} height={24} className="object-contain" />}
                         <span>{org?.siteName || "myJournal"}</span>
                     </Link>
                 </div>

--- a/components/DashboardShell.tsx
+++ b/components/DashboardShell.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import { StreakBadge } from './StreakBadge'
 import { useBranding } from './BrandingProvider'
 
@@ -57,7 +58,7 @@ export function DashboardShell({ sidebar, children, streak }: Props) {
                             </svg>
                         </button>
                         <Link href="/dashboard" className="text-lg font-bold text-white flex items-center gap-2">
-                            {logoUrl && <img src={logoUrl} alt="Logo" className="w-6 h-6 object-contain" />}
+                            {logoUrl && <Image src={logoUrl} alt="Logo" width={24} height={24} className="object-contain" />}
                             <span>{siteName}</span>
                         </Link>
                     </div>


### PR DESCRIPTION
## Summary
- Replaces 6 `<img>` tags with Next.js `<Image>` component across 5 files
- Covers landing page, dashboard, sidebar, stats, and settings pages
- Enables automatic lazy loading, WebP/AVIF conversion, and responsive sizing
- Intentionally leaves `ProfileForm.tsx` as `<img>` (uses client-side blob URLs)

## Test plan
- [ ] Verify logos render correctly on landing page, dashboard sidebar, stats, and settings
- [ ] Verify user avatars render correctly in the dashboard sidebar
- [ ] Check browser Network tab — images should be served as WebP/AVIF

🤖 Generated with [Claude Code](https://claude.com/claude-code)