### PR TITLE
perf: eliminate duplicate queries in DailyJournalForm

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -149,7 +149,14 @@ export default async function DashboardPage({ searchParams }: Props) {
             ContentComponent = <div className="text-muted-foreground p-10">User has not journaled today.</div>
         }
     } else {
-        ContentComponent = <DailyJournalForm />
+        // Fetch today's existing answers to pre-fill the form
+        const todayEntries = await getEntriesByDate(targetUserId, today);
+        const initialAnswers = todayEntries.reduce((acc, entry) => {
+            acc[entry.promptId] = entry.answer;
+            return acc;
+        }, {} as Record<string, string>);
+
+        ContentComponent = <DailyJournalForm prompts={activePrompts} initialAnswers={initialAnswers} />
     }
 
     const userLabel = isAdmin

--- a/components/DailyJournalForm.tsx
+++ b/components/DailyJournalForm.tsx
@@ -1,40 +1,13 @@
 
-import { getActivePrompts, getEffectiveProfileIds, getEntriesByDate } from "@/app/lib/data"
-import { auth } from "@/auth"
-import { prisma } from "@/lib/prisma"
 import { JournalEditor } from "./JournalEditor"
+import { Prompt } from "@prisma/client"
 
-export async function DailyJournalForm() {
-    const session = await auth();
-    const currentUserId = session?.user?.id || '';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let organizationId = (session?.user as any)?.organizationId as string;
+type Props = {
+    prompts: Prompt[]
+    initialAnswers: Record<string, string>
+}
 
-    // Fallback: Resolve Org ID if session is missing it
-    if (session?.user?.email && !organizationId) {
-        const user = await prisma.user.findUnique({ where: { email: session.user.email } })
-        if (user) organizationId = user.organizationId;
-    }
-
-    const userProfileIds = await getEffectiveProfileIds(currentUserId);
-    const prompts = await getActivePrompts(currentUserId, organizationId, userProfileIds);
-
-    // Fetch existing answers for today (Server Local Time)
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const todayStr = `${year}-${month}-${day}`;
-    let initialAnswers: Record<string, string> = {};
-
-    if (currentUserId) {
-        const existingEntries = await getEntriesByDate(currentUserId, todayStr);
-        initialAnswers = existingEntries.reduce((acc, entry) => {
-            acc[entry.promptId] = entry.answer;
-            return acc;
-        }, {} as Record<string, string>);
-    }
-
+export function DailyJournalForm({ prompts, initialAnswers }: Props) {
     return (
         <JournalEditor prompts={prompts} initialAnswers={initialAnswers} />
     )


### PR DESCRIPTION
## Summary
- `DailyJournalForm` no longer fetches auth, profiles, or prompts internally
- Parent dashboard page passes `prompts` and `initialAnswers` as props
- Removes 4 redundant database queries on every dashboard load
- Bonus: entry fetching now uses timezone-aware date (was server-local time)

## Test plan
- [ ] Load the dashboard for today — verify all prompts render with existing answers pre-filled
- [ ] Edit an answer and confirm auto-save still works
- [ ] Refresh the page and verify saved answers persist
- [ ] Log in as a new user with no entries — verify empty form renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)