### PR TITLE
fix: batch 4 code quality and tech debt

### DIFF
--- a/app/actions/feedback.ts
+++ b/app/actions/feedback.ts
@@ -7,7 +7,7 @@ import { revalidatePath } from "next/cache"
 export async function toggleEntryLike(entryId: string) {
     try {
         const session = await auth()
-        const user = session?.user as any; // Cast to access role
+        const user = session?.user
         if (!user || user.role !== 'ADMIN') {
             return { error: "Unauthorized" }
         }

--- a/app/actions/groups.ts
+++ b/app/actions/groups.ts
@@ -13,12 +13,6 @@ export async function createGroup(formData: FormData) {
     const description = formData.get('description') as string;
     const profileId = formData.get('profileId') as string;
 
-    // Users are passed as comma-separated emails or JSON string of IDs/emails?
-    // Let's stick to the UI plan: Add Initial Users via multi-select or just one-by-one later?
-    // The user said: "The add users option should use the same control that exists on the dialog used when editing a profile." -> Wait, that's complex to replicate in a simple create form.
-    // Let's assume for v1 we just allow Profile first. adding users can be done in edit mode or via a simple comma-seperated list if needed.
-    // BUT the prompt said: "In the New Group, we should allow a user to pick a profile and add users."
-    // Let's support an array of emails if posted.
     const initialEmails = formData.getAll('initialUsers') as string[];
 
     try {

--- a/app/actions/groups.ts
+++ b/app/actions/groups.ts
@@ -7,8 +7,7 @@ import { ensureAdmin } from './helpers'
 // Enhanced createGroup to handle initial profile and users
 export async function createGroup(formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const name = formData.get('name') as string;
     const description = formData.get('description') as string;

--- a/app/actions/profiles.ts
+++ b/app/actions/profiles.ts
@@ -6,8 +6,7 @@ import { ensureAdmin } from './helpers'
 
 export async function createProfile(formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const name = formData.get('name') as string;
     const description = formData.get('description') as string;
@@ -50,8 +49,7 @@ export async function deleteProfile(id: string) {
 
 export async function addProfileRule(profileId: string, formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const categoryId = formData.get('categoryId') as string;
     // Fallback or legacy support
@@ -113,8 +111,7 @@ export async function addProfileRule(profileId: string, formData: FormData) {
 
 export async function updateProfileRule(ruleId: string, profileId: string, formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const categoryId = formData.get('categoryId') as string;
     const categoryString = formData.get('categoryString') as string; // Legacy fallback

--- a/app/actions/prompts.ts
+++ b/app/actions/prompts.ts
@@ -8,8 +8,7 @@ import { ensureAdmin } from './helpers'
 
 export async function createPromptCategory(formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
     const name = formData.get('name') as string;
 
     if (!name) return { error: 'Name required' };
@@ -30,8 +29,7 @@ export async function createPromptCategory(formData: FormData) {
 
 export async function deletePromptCategory(id: string) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     try {
         // Find or create the _archived category for this org
@@ -82,8 +80,7 @@ export async function deletePromptCategory(id: string) {
 
 export async function createPrompt(formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const content = formData.get('content') as string;
     const type = formData.get('type') as string; // 'TEXT', 'RADIO', 'CHECKBOX'
@@ -149,8 +146,7 @@ export async function createPrompt(formData: FormData) {
 
 export async function updatePrompt(id: string, formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const content = formData.get('content') as string;
     const type = formData.get('type') as string;
@@ -256,8 +252,7 @@ export async function reorderPrompts(items: { id: string; sortOrder: number }[])
 
 export async function importPrompts(formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const file = formData.get('file') as File | null;
     if (!file) return { error: "No file provided" };

--- a/app/actions/restore.ts
+++ b/app/actions/restore.ts
@@ -35,7 +35,7 @@ type RestoreReport = {
 export async function restoreSystemData(formData: FormData) {
     // 1. Auth Check
     const session = await auth()
-    const user = session?.user as any
+    const user = session?.user
     if (!user || user.role !== 'ADMIN') {
         return { error: "Unauthorized" }
     }

--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { resolveUserId } from "@/lib/auth-helpers"
 import { revalidatePath } from "next/cache"
 import { writeFile, unlink } from "fs/promises"
+import { existsSync, mkdirSync } from "fs"
 import { join } from "path"
 import { randomUUID } from 'crypto'
 
@@ -44,11 +45,10 @@ export async function updateProfile(userId: string, formData: FormData) {
         const url = `/uploads/avatars/${filename}`
 
         // Ensure directory exists (node fs/promises doesn't have ensureDir, assume public exists or we create it?)
-        // Let's assume public/uploads/avatars exists for now or user manual creation? 
+        // Let's assume public/uploads/avatars exists for now or user manual creation?
         // Better: try to mkdir
-        const fs = require('fs')
-        if (!fs.existsSync(uploadDir)) {
-            fs.mkdirSync(uploadDir, { recursive: true });
+        if (!existsSync(uploadDir)) {
+            mkdirSync(uploadDir, { recursive: true });
         }
 
         // Write file
@@ -69,7 +69,7 @@ export async function updateProfile(userId: string, formData: FormData) {
             // Delete old file
             try {
                 const oldPath = join(process.cwd(), "public", oldAvatar.url)
-                if (fs.existsSync(oldPath)) {
+                if (existsSync(oldPath)) {
                     await unlink(oldPath)
                 }
             } catch (e) {

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -11,8 +11,7 @@ import { ASSIGNMENT_MODES } from '@/lib/taskConstants'
 
 export async function createTask(formData: FormData) {
     const session = await ensureAdmin()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string
+    const organizationId = session.user.organizationId
 
     const title = formData.get('title') as string
     const description = formData.get('description') as string | null
@@ -111,8 +110,7 @@ export async function createTask(formData: FormData) {
 
 export async function updateTask(taskId: string, formData: FormData) {
     const session = await ensureAdmin()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string
+    const organizationId = session.user.organizationId
 
     const title = formData.get('title') as string
     const description = formData.get('description') as string | null
@@ -195,8 +193,7 @@ export async function updateTask(taskId: string, formData: FormData) {
 
 export async function archiveTask(taskId: string) {
     const session = await ensureAdmin()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string
+    const organizationId = session.user.organizationId
 
     try {
         const task = await prisma.task.findUnique({ where: { id: taskId } })
@@ -220,8 +217,7 @@ export async function archiveTask(taskId: string) {
 
 export async function unarchiveTask(taskId: string) {
     const session = await ensureAdmin()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string
+    const organizationId = session.user.organizationId
 
     try {
         const task = await prisma.task.findUnique({ where: { id: taskId } })
@@ -257,8 +253,7 @@ export async function completeTask(assignmentId: string, notes?: string) {
 
         if (!assignment) return { error: 'Assignment not found' }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const orgId = (session.user as any)?.organizationId as string
+        const orgId = session.user.organizationId
         if (assignment.task.organizationId !== orgId) {
             return { error: 'Unauthorized' }
         }
@@ -297,8 +292,7 @@ export async function uncompleteTask(assignmentId: string) {
 
         if (!assignment) return { error: 'Assignment not found' }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const orgId = (session.user as any)?.organizationId as string
+        const orgId = session.user.organizationId
         if (assignment.task.organizationId !== orgId) {
             return { error: 'Unauthorized' }
         }

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -10,8 +10,7 @@ import { ensureAdmin } from './helpers'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function createUser(prevState: any, formData: FormData) {
     const session = await ensureAdmin();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const organizationId = (session?.user as any)?.organizationId as string;
+    const organizationId = session.user.organizationId;
 
     const email = formData.get('email') as string;
     const name = formData.get('name') as string;

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -8,7 +8,7 @@ import { createGroup, deleteGroup } from "@/app/actions/groups"
 export default async function AdminGroupsPage() {
     const session = await auth();
 
-    if (!session?.user || (session.user as any).role !== 'ADMIN') {
+    if (!session?.user || session.user.role !== 'ADMIN') {
         redirect("/dashboard")
     }
 

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default async function AdminPage() {
     const session = await auth()
 
-    if (!session?.user || (session.user as any).role !== 'ADMIN') {
+    if (!session?.user || session.user.role !== 'ADMIN') {
         redirect("/dashboard")
     }
 

--- a/app/admin/prompts/page.tsx
+++ b/app/admin/prompts/page.tsx
@@ -16,7 +16,7 @@ type Props = {
 export default async function AdminPromptsPage({ searchParams }: Props) {
     const session = await auth();
 
-    if (!session?.user || (session.user as any).role !== 'ADMIN') {
+    if (!session?.user || session.user.role !== 'ADMIN') {
         redirect("/dashboard")
     }
 

--- a/app/admin/tasks/[id]/edit/page.tsx
+++ b/app/admin/tasks/[id]/edit/page.tsx
@@ -11,10 +11,8 @@ type Props = {
 
 export default async function EditTaskPage({ params }: Props) {
     const session = await auth()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const orgId = (session?.user as any)?.organizationId as string
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (!session?.user || (session.user as any).role !== 'ADMIN' || !orgId) {
+    const orgId = session?.user?.organizationId
+    if (!session?.user || session.user.role !== 'ADMIN' || !orgId) {
         notFound()
     }
 

--- a/app/admin/tasks/[id]/page.tsx
+++ b/app/admin/tasks/[id]/page.tsx
@@ -12,10 +12,8 @@ type Props = {
 
 export default async function TaskDetailPage({ params }: Props) {
     const session = await auth()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const orgId = (session?.user as any)?.organizationId as string
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (!session?.user || (session.user as any).role !== 'ADMIN' || !orgId) {
+    const orgId = session?.user?.organizationId
+    if (!session?.user || session.user.role !== 'ADMIN' || !orgId) {
         notFound()
     }
 

--- a/app/admin/tasks/page.tsx
+++ b/app/admin/tasks/page.tsx
@@ -14,11 +14,11 @@ type Props = {
 export default async function AdminTasksPage({ searchParams }: Props) {
     const session = await auth();
 
-    if (!session?.user || (session.user as any).role !== 'ADMIN') {
+    if (!session?.user || session.user.role !== 'ADMIN') {
         redirect("/dashboard")
     }
 
-    const orgId = (session?.user as any)?.organizationId;
+    const orgId = session.user.organizationId;
     const params = await searchParams;
     const tab = typeof params.tab === 'string' ? params.tab : 'active';
     const isArchived = tab === 'archived';

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -11,7 +11,7 @@ import { DeleteUserDialog } from "@/components/admin/DeleteUserDialog"
 export default async function AdminUsersPage() {
     const session = await auth()
 
-    if (!session?.user || (session.user as any).role !== 'ADMIN') {
+    if (!session?.user || session.user.role !== 'ADMIN') {
         redirect("/dashboard")
     }
 

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -12,15 +12,14 @@ export async function GET() {
     try {
         // 1. Security Check
         const session = await auth()
-        // Force type assertion or check properties safely since NextAuth types can be tricky
-        const user = session?.user as any
+        const user = session?.user
 
         if (!user || user.role !== 'ADMIN') {
             return new NextResponse("Unauthorized", { status: 401 })
         }
 
         // 2. Data Fetching
-        const organizationId = user.organizationId as string
+        const organizationId = user.organizationId
 
         const organizations = await prisma.organization.findMany({
             where: { id: organizationId }

--- a/app/api/v1/stats/route.ts
+++ b/app/api/v1/stats/route.ts
@@ -115,7 +115,7 @@ export async function GET(request: NextRequest) {
     const taskMap = new Map<string, { prompt: string; days: Set<string> }>()
 
     entries.forEach((e) => {
-      if (['CHECKBOX', 'RADIO', 'Checkboxes', 'Radio'].includes(e.prompt.type)) {
+      if (['CHECKBOX', 'RADIO'].includes(e.prompt.type)) {
         if (!taskMap.has(e.prompt.id)) {
           taskMap.set(e.prompt.id, { prompt: e.prompt.content, days: new Set() })
         }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -91,7 +91,7 @@ export default async function DashboardPage({ searchParams }: Props) {
         prisma.taskAssignment.findMany({
             where: {
                 userId: targetUserId,
-                task: { archivedAt: null, organizationId: (session?.user as any)?.organizationId || '' }
+                task: { archivedAt: null, organizationId: session.user.organizationId }
             },
             include: { task: true }
         })

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -166,7 +166,7 @@ export const getUserStats = cache(async function getUserStats(userId: string) {
 
     entries.forEach(e => {
         // Habits (Checkboxes / Radio)
-        if (['Checkboxes', 'Radio', 'CHECKBOX', 'RADIO'].includes(e.prompt.type)) {
+        if (['CHECKBOX', 'RADIO'].includes(e.prompt.type)) {
             if (!taskMap.has(e.prompt.id)) {
                 taskMap.set(e.prompt.id, { prompt: e.prompt.content, type: e.prompt.type, days: new Set() });
             }

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -197,10 +197,10 @@ export async function getActivePrompts(
                 // Build pool from pre-fetched data, excluding already-selected prompts
                 let pool: typeof allCandidatePrompts = [];
 
-                if (rule.categoryString) {
-                    pool = [...(promptsByCategoryString.get(rule.categoryString) || [])];
-                } else if (rule.categoryId) {
+                if (rule.categoryId) {
                     pool = [...(promptsByCategoryId.get(rule.categoryId) || [])];
+                } else if (rule.categoryString) {
+                    pool = [...(promptsByCategoryString.get(rule.categoryString) || [])];
                 } else {
                     continue;
                 }

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -229,11 +229,6 @@ export async function getActivePrompts(
             }
         }
 
-        // Return combined list, maybe sorted by some logic? 
-        // For now, Globals first, then mixed. OR just all sorted by createdAt or something.
-        // Let's keep Globals at top, then others.
-
-        // Actually, Map preserves insertion order mostly.
         return Array.from(selectedPromptsMap.values());
 
     } catch (error) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -206,11 +206,7 @@ model JournalEntry {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([userId, promptId, date]) // Prevent duplicate answers for the same prompt per day?
-  // Actually, 'date' might be too granular (timestamp).
-  // For "daily", we might want to store just the YYYY-MM-DD string or normalize the date.
-  // For now, let's keep it simple and maybe just index them.
-  // If unique constraint is problematic with timestamps, I'll remove it or manage it in app logic.
+  @@unique([userId, promptId, date])
 
   @@index([userId, createdAt])
   @@index([userId, promptId, createdAt])

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -10,12 +10,12 @@ declare module "next-auth" {
             role: string
             /** The user's ID. */
             id: string
-            organizationId?: string
+            organizationId: string
         } & DefaultSession["user"]
     }
 
     interface User {
         role: string
-        organizationId?: string
+        organizationId: string
     }
 }


### PR DESCRIPTION
## Summary

- **Remove `as any` casts** — made `organizationId` required in NextAuth type declaration, removed ~30 `as any` casts across 17 files (closes #24)
- **Clean up dead comments** — removed thinking-aloud dev notes from data.ts, groups.ts, schema.prisma (closes #25)
- **Remove mixed-case prompt type checks** — prod only uses uppercase types (TEXT, RADIO, RANGE), removed dead `Checkboxes`/`Radio` checks (closes #26)
- **Replace `require('fs')` with ES import** — proper import in settings.ts (closes #27)
- **Prioritize categoryId over categoryString** — prompt pool selection now matches on `categoryId` first, falling back to `categoryString` for backward compat. Prevents future casing bugs. (closes #30)

## Test plan

- [x] TypeScript: zero errors
- [x] Production build: passes
- No user-facing changes — all internal code quality improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)